### PR TITLE
update riscv-rt version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ch32v2 = { path = "../ch32-rs-nightlies/ch32v2", features = [
 ] }
 # provide implementation for critical-section
 riscv = { version = "0.10.0", features = ["critical-section-single-hart"] }
-riscv-rt = "0.10"
+riscv-rt = "0.11.0"
 panic-halt = "0.2.0"
 
 embedded-hal = "1.0.0-alpha.9"


### PR DESCRIPTION
Today, I 'git clone'ed `ch32v203-demo`, and got `rust-analyzer` error below:
```
[ERROR rust_analyzer::main_loop] FetchWorkspaceError:
rust-analyzer failed to load workspace: Failed to load the project at /Users/DicklessGreat/MyPath/ch32v203-demo/Cargo.toml: Failed to read Cargo metadata from Cargo.toml file /Users/DicklessGreat/MyPath/ch32v203-demo/Cargo.toml, Some(Version { major: 1, minor: 74, patch: 1 }): Failed to run `cd "/Users/DicklessGreat/MyPath/ch32v203-demo" && "cargo" "metadata" "--format-version" "1" "--manifest-path" "/Users/DicklessGreat/MyPath/ch32v203-demo/Cargo.toml" "--filter-platform" "riscv32imac-unknown-none-elf"`: `cargo metadata` exited with an error:     Updating crates.io index
error: failed to select a version for the requirement `riscv-rt = "^0.10"`
candidate versions found which didn't match: 0.11.0, 0.9.0, 0.8.1, ...
location searched: crates.io index
required by package `ch32v203-demo v0.1.0 (/Users/DicklessGreat/MyPath/ch32v203-demo)`
perhaps a crate was updated and forgotten to be re-vendored?
```
That's why I replaced `riscv-rt = "0.10"` with `riscv-rt = "0.11.0"` in `Cargo.toml`.